### PR TITLE
Feature/set number of working days

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -59,6 +59,27 @@
       </div>
 
       <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
+        <p class="text-sm w-fit">Number of days off taken in a year</p>
+        <!-- This input field accepts negative values, with a minimum limit that ensures the total number of working days in a year does not exceed 365.  -->
+        <AdjustCounter
+          :value="store.nrDaysOff"
+          @update:value="store.setNrDaysOff"
+          :min="YEAR_BUSINESS_DAYS - 365" 
+          :max="YEAR_BUSINESS_DAYS - 1"
+          unit="days"
+          data-cy="nr-days-off"
+        /> 
+        <InfoButton>
+          <p class="text-sm w-64 text-center">
+            Set the number of unpaid days off or unpaid vacation days you plan to 
+            take during the year. These days will be deducted from the annual 
+            income calculation.
+            This simulation assumes that one year consists of {{YEAR_BUSINESS_DAYS}} working days.
+          </p>
+        </InfoButton>
+      </div>
+
+      <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
         <p class="text-sm w-fit">Adjust your contribution to social security</p>
         <AdjustCounter
           v-model:value="ssDiscountPosition"
@@ -277,7 +298,7 @@ import { storeToRefs } from "pinia";
 
 import { asCurrency } from "@/utils.js";
 import { FrequencyChoices } from "@/typings";
-import { SUPPORTED_TAX_RANK_YEARS, useTaxesStore } from "@/store";
+import { SUPPORTED_TAX_RANK_YEARS, useTaxesStore, YEAR_BUSINESS_DAYS } from "@/store";
 import { ArrowPathIcon } from "@heroicons/vue/24/outline";
 
 import Chart from "@/components/Chart.vue";
@@ -294,6 +315,7 @@ const {
   taxesDisplay,
   ssDisplay,
   nrMonthsDisplay,
+  nrDaysOff,
   irsDisplay,
   expensesNeeded,
   grossIncome,

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -24,7 +24,7 @@
       </div>
       <div class="flex ml-3 md:ml-0 justify-start items-center mt-2 space-x-4">
         <p class="text-sm w-fit">Income tax year</p>
-        <div class="w-16">
+        <div class="w-20">
           <DropDown
             :choices="SUPPORTED_TAX_RANK_YEARS"
             @change="changeCurrentTaxRankYear"

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,7 @@ import { updateUrlQuery, clearUrlQuery } from "@/router";
 
 export const YEAR_BUSINESS_DAYS = 248;
 export const MONTH_BUSINESS_DAYS = 22;
-export const SUPPORTED_TAX_RANK_YEARS = [2023, 2024];
+export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024]).sort((a, b) => b - a);
 const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
 interface TaxesState {
@@ -606,7 +606,7 @@ const useTaxesStore = defineStore({
       this.setNrMonthsDisplay(12);
       this.setSsDiscount(0);
       this.setExpenses(0);
-      this.setCurrentTaxRankYear(2023);
+      this.setCurrentTaxRankYear( SUPPORTED_TAX_RANK_YEARS[0] );
       this.setSsFirstYear(false);
       this.setFirstYear(false);
       this.setSecondYear(false);

--- a/src/store/taxes.spec.ts
+++ b/src/store/taxes.spec.ts
@@ -47,7 +47,7 @@ describe("Taxes Store", () => {
     expect(taxesStore.grossIncome.year).toBe(newGrossIncome * MONTHS_IN_YEAR);
     expect(taxesStore.grossIncome.month).toBe(newGrossIncome);
     expect(taxesStore.grossIncome.day).toBe(
-      newGrossIncome / MONTH_BUSINESS_DAYS,
+      taxesStore.grossIncome.year / YEAR_BUSINESS_DAYS,
     );
   });
 
@@ -61,7 +61,7 @@ describe("Taxes Store", () => {
       newGrossIncome * YEAR_BUSINESS_DAYS,
     );
     expect(taxesStore.grossIncome.month).toBe(
-      newGrossIncome * MONTH_BUSINESS_DAYS,
+      taxesStore.grossIncome.year / MONTHS_IN_YEAR,
     );
     expect(taxesStore.grossIncome.day).toBe(newGrossIncome);
   });


### PR DESCRIPTION
Functionality

> - Created new input field where the user can set the number of days off in a year
> - Adjusted the logic to calculate the monthly salary to consider only the number of months, rather than number of days in a month
> - Updated Vitest to reflect changes on the income calculation method


Cosmetics:

> - Increase width of the dropdown field to select the Tax Year so that the options are readable without the need of horizontal scrolling
> - Reorder the options for Tax Year in descending order
> - When resetting the simulation, reset the Tax Year to the first option on the list