### PR TITLE
Redesign monthly and daily calculations:

### DIFF
--- a/src/components/FooterBar.vue
+++ b/src/components/FooterBar.vue
@@ -36,8 +36,7 @@
             <XMarkIcon class="w-5 h-5" />
           </button>
           <div class="text-xs">
-            *Assuming 248 business days in a year and 22 business days in a
-            month.
+            *Assuming {{ YEAR_BUSINESS_DAYS }} business days in a year.
           </div>
           <div class="text-xs">
             This is only valid for independent workers with green receipts
@@ -63,7 +62,10 @@
 </template>
 <script lang="ts" setup>
 import { storeToRefs } from "pinia";
-import { useTaxesStore } from "@/store";
+import { 
+  useTaxesStore,
+  YEAR_BUSINESS_DAYS
+ } from "@/store";
 import { useBreakpoint } from "@/composables/breakpoints";
 import { XMarkIcon } from "@heroicons/vue/24/outline";
 import { ref } from "vue";

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,9 +9,10 @@ import {
 } from "@/typings";
 import { asCurrency, generateUUID } from "@/utils.js";
 import { updateUrlQuery, clearUrlQuery } from "@/router";
+import { ssrExportAllKey } from "vite/runtime";
 
 export const YEAR_BUSINESS_DAYS = 248;
-export const MONTH_BUSINESS_DAYS = 22;
+//export const MONTH_BUSINESS_DAYS = 22; // No longer used by this simulator, only year business days are taken into account
 export const SUPPORTED_TAX_RANK_YEARS = ([2023, 2024]).sort((a, b) => b - a);
 const SIMULATIONS_LOCAL_STORE_KEY = "net_income_simulations";
 
@@ -180,10 +181,11 @@ const useTaxesStore = defineStore({
           this.maxSsIncome,
           this.grossIncome.month * 0.7 * (1 + this.ssDiscount),
         );
+      const yearSSPay = Math.max(12 * monthSS, 20 * 12);
       return {
-        year: Math.max(12 * monthSS, 20 * 12),
+        year: yearSSPay,
         month: Math.max(monthSS, 20),
-        day: monthSS / MONTH_BUSINESS_DAYS,
+        day: yearSSPay / (YEAR_BUSINESS_DAYS - this.nrDaysOff),
       };
     },
     specificDeductions() {
@@ -304,7 +306,7 @@ const useTaxesStore = defineStore({
       return {
         year: Math.max(yearIRS, 0),
         month: monthIRS,
-        day: monthIRS / MONTH_BUSINESS_DAYS,
+        day: Math.max(yearIRS, 0) / (YEAR_BUSINESS_DAYS - this.nrDaysOff),
       };
     },
     taxesDisplay() {
@@ -318,7 +320,8 @@ const useTaxesStore = defineStore({
       return {
         year: this.grossIncome.year - this.irsPay.year - this.ssPay.year,
         month: monthIncome,
-        day: monthIncome / MONTH_BUSINESS_DAYS,
+        day: (this.grossIncome.year - this.irsPay.year - this.ssPay.year) / 
+        (YEAR_BUSINESS_DAYS - this.nrDaysOff),
       };
     },
     irsFrequency() {

--- a/src/store/taxes.spec.ts
+++ b/src/store/taxes.spec.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import { createPinia } from "pinia";
 import {
-  MONTH_BUSINESS_DAYS,
   SUPPORTED_TAX_RANK_YEARS,
   YEAR_BUSINESS_DAYS,
   useTaxesStore,
@@ -87,9 +86,7 @@ describe("Taxes Store", () => {
         (SS_TAX * (newGrossIncome * 0.7)) / MONTHS_IN_YEAR,
       );
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * (newGrossIncome * 0.7)) /
-          MONTHS_IN_YEAR /
-          MONTH_BUSINESS_DAYS,
+        (SS_TAX * (newGrossIncome * 0.7)) / YEAR_BUSINESS_DAYS,
       );
     });
 
@@ -102,7 +99,7 @@ describe("Taxes Store", () => {
       );
       expect(taxesStore.ssPay.month).toBe(SS_TAX * taxesStore.maxSsIncome);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * taxesStore.maxSsIncome) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * taxesStore.maxSsIncome) * MONTHS_IN_YEAR / YEAR_BUSINESS_DAYS,
       );
     });
 
@@ -118,7 +115,7 @@ describe("Taxes Store", () => {
       expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
       expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * monthlySsPay) * MONTHS_IN_YEAR / YEAR_BUSINESS_DAYS,
       );
     });
 
@@ -134,7 +131,7 @@ describe("Taxes Store", () => {
       expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
       expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * monthlySsPay) * MONTHS_IN_YEAR / YEAR_BUSINESS_DAYS,
       );
     });
 
@@ -153,7 +150,7 @@ describe("Taxes Store", () => {
       expect(taxesStore.ssPay.year).toBe(SS_TAX * monthlySsPay * MONTHS_IN_YEAR);
       expect(taxesStore.ssPay.month).toBe(SS_TAX * monthlySsPay);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * monthlySsPay) / MONTH_BUSINESS_DAYS
+        (SS_TAX * monthlySsPay) * MONTHS_IN_YEAR / YEAR_BUSINESS_DAYS
       );
     });
 
@@ -170,7 +167,7 @@ describe("Taxes Store", () => {
       );
       expect(taxesStore.ssPay.month).toBe(SS_TAX * taxesStore.maxSsIncome);
       expect(taxesStore.ssPay.day).toBe(
-        (SS_TAX * taxesStore.maxSsIncome) / MONTH_BUSINESS_DAYS,
+        (SS_TAX * taxesStore.maxSsIncome) * MONTHS_IN_YEAR / YEAR_BUSINESS_DAYS,
       );
     });
   });
@@ -286,7 +283,7 @@ describe("Taxes Store", () => {
     expect(taxesStore.irsPay?.year).toBe(yearIRSCalculation);
     expect(taxesStore.irsPay?.month).toBe(yearIRSCalculation / MONTHS_IN_YEAR);
     expect(taxesStore.irsPay?.day).toBe(
-      yearIRSCalculation / MONTHS_IN_YEAR / MONTH_BUSINESS_DAYS,
+      yearIRSCalculation / YEAR_BUSINESS_DAYS,
     );
   });
 
@@ -300,7 +297,7 @@ describe("Taxes Store", () => {
       yearNHRIRSCalculation / MONTHS_IN_YEAR,
     );
     expect(taxesStore.irsPay?.day).toBe(
-      yearNHRIRSCalculation / MONTHS_IN_YEAR / MONTH_BUSINESS_DAYS,
+      yearNHRIRSCalculation / YEAR_BUSINESS_DAYS,
     );
   });
 
@@ -322,10 +319,10 @@ describe("Taxes Store", () => {
     );
 
     expect(taxesStore.netIncome.day).toBe(
-      (DEFAULT_INCOME / MONTHS_IN_YEAR -
-        taxesStore.irsPay?.month -
-        taxesStore.ssPay?.month) /
-        MONTH_BUSINESS_DAYS,
+      (DEFAULT_INCOME -
+        taxesStore.irsPay?.year -
+        taxesStore.ssPay?.year) /
+        YEAR_BUSINESS_DAYS,
     );
   });
 


### PR DESCRIPTION
- Change calculations to take into account only the number of months and the number of working days in a year. It should no longer take into consideration the number of working days in a month.
- Remove reference to the number of working days in a month from the footer note.